### PR TITLE
Use full URL for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cor-asv-fst-models"]
 	path = models
-	url = ../cor-asv-fst-models
+	url = https://github.com/ASVLeipzig//cor-asv-fst-models.git


### PR DESCRIPTION
All other repositories for OCR-D use full URLs. Using it here, too, makes it easier to evaluate all dependencies of OCR-D.